### PR TITLE
fix: typo in torch.backends

### DIFF
--- a/PyTorch.ipynb
+++ b/PyTorch.ipynb
@@ -1146,7 +1146,7 @@
         "    \n",
         "# Additionally, some operations on a GPU are implemented stochastically for efficiency\n",
         "# We want to ensure that all operations are deterministic on GPU (if used) for reproducibility\n",
-        "torch.backends.cudnn.determinstic = True\n",
+        "torch.backends.cudnn.deterministic = True\n",
         "torch.backends.cudnn.benchmark = False"
       ]
     },


### PR DESCRIPTION
There was a typo in the following setting: 

`torch.backends.cudnn.determinstic` => `torch.backends.cudnn.deterministic`