### PR TITLE
fix: typo in occupations in T4 notebook

### DIFF
--- a/T4.ipynb
+++ b/T4.ipynb
@@ -835,7 +835,7 @@
     "    \"skipper\",\n",
     "    \"protege\",\n",
     "    \"philosopher\",\n",
-    "    \"capitain\",\n",
+    "    \"captain\",\n",
     "    \"architect\",\n",
     "    \"financier\",\n",
     "    \"warrior\",\n",


### PR DESCRIPTION
This PR introduces another typo fix.